### PR TITLE
chore: Add GitHub issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,39 @@
+name: "Bug Report"
+description: "Report software deficiencies"
+labels: ["bug"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        Use this form to report any functional or performance bugs you've found in the software.
+        Be sure to check if your [issue](https://github.com/y-scope/ystdlib-cpp/issues) has already
+        been reported.
+  - type: "textarea"
+    attributes:
+      label: "Bug"
+      description: "Describe what's wrong and if applicable, what you expected instead."
+    validations:
+      required: true
+
+  - type: "input"
+    attributes:
+      label: "ystdlib-cpp version"
+      description: "The release version number or development commit hash that has the bug."
+      placeholder: "Version number or commit hash"
+    validations:
+      required: true
+
+  - type: "textarea"
+    attributes:
+      label: "Environment"
+      description: "The environment in which you're running ystdlib-cpp."
+      placeholder: "OS version, Docker version, etc."
+    validations:
+      required: true
+
+  - type: "textarea"
+    attributes:
+      label: "Reproduction steps"
+      description: "List each step required to reproduce the bug."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -10,7 +10,7 @@ body:
         Be sure to check if your [issue](https://github.com/y-scope/ystdlib-cpp/issues) has already
         been reported.
 
-    - type: "textarea"
+  - type: "textarea"
     attributes:
       label: "Bug"
       description: "Describe what's wrong and if applicable, what you expected instead."

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -6,9 +6,11 @@ body:
     attributes:
       value: |
         Use this form to report any functional or performance bugs you've found in the software.
+
         Be sure to check if your [issue](https://github.com/y-scope/ystdlib-cpp/issues) has already
         been reported.
-  - type: "textarea"
+
+    - type: "textarea"
     attributes:
       label: "Bug"
       description: "Describe what's wrong and if applicable, what you expected instead."

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,21 @@
+name: "Feature/Change Request"
+description: "Request a feature or change"
+labels: ["enhancement"]
+body:
+  - type: "markdown"
+    attributes:
+      value: |
+        Use this form to request a feature/change in the software, or the project as a whole.
+  - type: "textarea"
+    attributes:
+      label: "Request"
+      description: "Describe your request and why it's important."
+    validations:
+      required: true
+
+  - type: "textarea"
+    attributes:
+      label: "Possible implementation"
+      description: "Describe any implementations you have in mind."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -6,7 +6,6 @@ body:
     attributes:
       value: |
         Use this form to request a feature/change in the software, or the project as a whole.
- 
   - type: "textarea"
     attributes:
       label: "Request"

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -6,6 +6,7 @@ body:
     attributes:
       value: |
         Use this form to request a feature/change in the software, or the project as a whole.
+ 
   - type: "textarea"
     attributes:
       label: "Request"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
Add GitHub issue templates according to the current practice in [clp](https://github.com/y-scope/clp/tree/1ecd9c75a8c59b45673cc97d131f85e4d796635a/.github/ISSUE_TEMPLATE).
Note that in [bug-report.yaml](https://github.com/y-scope/ystdlib-cpp/pull/7/files#diff-fe9734cc5d2a0e1916553dbc343214eab5630814c0b0a27d1370c4569afaea67), all occurrences of repo names have been updated from `clp` to `ystdlib-cpp`.


# Validation performed
- [x] Newly opened GitHub issues/feature-requests follow the templates in this PR.
