### PR TITLE
ci: Add GitHub workflow to run code linting checks daily, on push, and on pull request.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -1,0 +1,53 @@
+name: "code-linting-checks"
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Run daily at 00:15 UTC (the 15 is to avoid periods of high load)
+    - cron: "15 0 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  lint-check:
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest"]
+    runs-on: "${{matrix.os}}"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: "recursive"
+
+      - uses: "actions/setup-python@v5"
+        with:
+          # NOTE: We resolve some of clang-tidy's IWYU violations using CPython 3.10's headers, so
+          # we need to use the same version of Python when running clang-tidy.
+          python-version: "3.10"
+
+      - name: "Install task"
+        shell: "bash"
+        run: "npm install -g @go-task/cli"
+
+      - name: "Log tool versions"
+        run: |-
+          md5sum --version
+          python --version
+          tar --version
+          task --version
+
+      - if: "matrix.os == 'macos-latest'"
+        name: "Install coreutils (for md5sum)"
+        run: "brew install coreutils"
+
+      - name: "Run lint task"
+        shell: "bash"
+        run: "task lint:check"

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -29,9 +29,7 @@ jobs:
 
       - uses: "actions/setup-python@v5"
         with:
-          # NOTE: We resolve some of clang-tidy's IWYU violations using CPython 3.10's headers, so
-          # we need to use the same version of Python when running clang-tidy.
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: "Install task"
         shell: "bash"

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -37,16 +37,16 @@ jobs:
         shell: "bash"
         run: "npm install -g @go-task/cli"
 
+      - if: "matrix.os == 'macos-latest'"
+        name: "Install coreutils (for md5sum)"
+        run: "brew install coreutils"
+
       - name: "Log tool versions"
         run: |-
           md5sum --version
           python --version
           tar --version
           task --version
-
-      - if: "matrix.os == 'macos-latest'"
-        name: "Install coreutils (for md5sum)"
-        run: "brew install coreutils"
 
       - name: "Run lint task"
         shell: "bash"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
With the first set of linters added (for YAML files), automated GitHub workflow to lint files can now be set up. 
This is important before we add more configuration YAML files to the project.

The linting workflow file follows the current practice in [clp](https://github.com/y-scope/clp/blob/8b3fd63fdcbc5eb3628673f8ff79f9399d244d29/.github/workflows/clp-lint.yaml), with three differences:
1. Changed the workflow name from `clp-lint` to `code-linting-checks`, which is more generic. 
2. Added `permissions: {}`, which disables all token permissions. This enhances security for workflows where no repository interactions are required.
3. Added a job `Log tool versions` for better debuggability.

For details, see [spider](https://github.com/sitaowang1998/spider/blob/4da85826d21a14e877176cf8261950a8a81caeb1/.github/workflows/code-linting-checks.yaml).

# Validation performed
- [x] Verified that all current workflows pass.
