### PR TITLE
fix: Drop `silent` flag from `lint:cmake-check` command; Remove GNU-specific xargs flag; Avoid running `lint:yaml` unnecessarily.

### DIFF
--- a/taskfiles/lint-cmake.yaml
+++ b/taskfiles/lint-cmake.yaml
@@ -16,7 +16,6 @@ tasks:
         vars:
           FLAGS: "--diff --color"
       - task: "gersemi"
-        silent: true
         vars:
           FLAGS: "--check"
 

--- a/taskfiles/lint-cmake.yaml
+++ b/taskfiles/lint-cmake.yaml
@@ -42,4 +42,4 @@ tasks:
           \( -path '**/build' -o -path '**/submodules' -o -path '**/tools' \) -prune -o \
           \( -iname "CMakeLists.txt" -o -iname "*.cmake" -o -iname "*.cmake.in" \) \
           -print0 | \
-            xargs -0 --no-run-if-empty gersemi {{.FLAGS}}
+            xargs -0 gersemi {{.FLAGS}}

--- a/taskfiles/lint-yaml.yaml
+++ b/taskfiles/lint-yaml.yaml
@@ -6,15 +6,23 @@ tasks:
       - "yaml-check"
       - "yaml-fix"
     desc: "Runs the YAML linters. Only checks for warnings and violations."
+    sources:
+      - "{{.ROOT_DIR}}/**/*.yaml"
+      - "{{.ROOT_DIR}}/**/*.yml"
+      - "{{.TASKFILE}}"
+      - exclude: "{{.ROOT_DIR}}/**/build/*"
+      - exclude: "{{.ROOT_DIR}}/**/submodules/*"
+      - exclude: "{{.ROOT_DIR}}/**/tools/*"
     deps:
       - "venv"
     dir: "{{.ROOT_DIR}}"
     cmds:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
-        yamllint \
-          --config-file "tools/yscope-dev-utils/lint-configs/.yamllint.yml" \
-          --strict \
-          .github \
-          taskfile.yaml \
-          taskfiles/
+        find . \
+          \( -path '**/build' -o -path '**/submodules' -o -path '**/tools' \) -prune -o \
+          \( -iname "*.yml" -o -iname "*.yaml" \) \
+          -print0 | \
+            xargs -0 yamllint \
+              --config-file "tools/yscope-dev-utils/lint-configs/.yamllint.yml" \
+              --strict

--- a/taskfiles/lint-yaml.yaml
+++ b/taskfiles/lint-yaml.yaml
@@ -21,7 +21,7 @@ tasks:
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
         find . \
           \( -path '**/build' -o -path '**/submodules' -o -path '**/tools' \) -prune -o \
-          \( -iname "*.yml" -o -iname "*.yaml" \) \
+          \( -iname "*.yaml" -o -iname "*.yml" \) \
           -print0 | \
             xargs -0 yamllint \
               --config-file "tools/yscope-dev-utils/lint-configs/.yamllint.yml" \


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
This PR fixes various issues with the current linters (YAML and CMake). See the PR title for what's fixed.


# Validation performed
- [x] Existing task workflows complete successfully.
