### PR TITLE
fix: Include the `venv` checksum file in the sources fields for all public linting tasks.

### DIFF
--- a/taskfiles/lint-cmake.yaml
+++ b/taskfiles/lint-cmake.yaml
@@ -4,6 +4,7 @@ tasks:
   cmake-check:
     desc: "Runs the CMake linters."
     sources: &cmake_format_src_files
+      - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
       - "{{.ROOT_DIR}}/**/*.cmake"
       - "{{.ROOT_DIR}}/**/*.cmake.in"
       - "{{.ROOT_DIR}}/**/CMakeLists.txt"
@@ -11,6 +12,8 @@ tasks:
       - exclude: "{{.ROOT_DIR}}/**/build/*"
       - exclude: "{{.ROOT_DIR}}/**/submodules/*"
       - exclude: "{{.ROOT_DIR}}/**/tools/*"
+    deps:
+      - "venv"
     cmds:
       - task: "gersemi"
         vars:
@@ -22,6 +25,8 @@ tasks:
   cmake-fix:
     desc: "Runs the CMake linters and fixes all violations."
     sources: *cmake_format_src_files
+    deps:
+      - "venv"
     cmds:
       - task: "gersemi"
         vars:

--- a/taskfiles/lint-yaml.yaml
+++ b/taskfiles/lint-yaml.yaml
@@ -7,15 +7,16 @@ tasks:
       - "yaml-fix"
     desc: "Runs the YAML linters. Only checks for warnings and violations."
     sources:
+      - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
       - "{{.ROOT_DIR}}/**/*.yaml"
       - "{{.ROOT_DIR}}/**/*.yml"
       - "{{.TASKFILE}}"
       - exclude: "{{.ROOT_DIR}}/**/build/*"
       - exclude: "{{.ROOT_DIR}}/**/submodules/*"
       - exclude: "{{.ROOT_DIR}}/**/tools/*"
+    dir: "{{.ROOT_DIR}}"
     deps:
       - "venv"
-    dir: "{{.ROOT_DIR}}"
     cmds:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
As discussed offline, a task containing both the `sources` and `deps` fields will always execute the tasks listed in `deps`, but it may skip running itself if the `sources` remain unchanged.

To ensure the parent task re-runs whenever the `venv` task is re-executed, we need to enforce this dependency. Otherwise, we risk missing tool version upgrades or inadvertently introducing linting issues.


# Validation performed
- [x] With the checksum files in `sources`, a re-run/ rebuild of `venv` properly triggers re-runs of all linting tasks.
