### PR TITLE
fix: Specify correct source path for `lint-requirements.txt`; Prevent `lint:venv` from running unnecessarily.

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -9,8 +9,7 @@ vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CMAKE_CACHE: "{{.G_BUILD_DIR}}/CMakeCache.txt"
   G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
-  # Project-specific variables
-  G_YSTDLIB_CPP_SRC_DIR: "{{.ROOT_DIR}}/src/ystdlib"
+  G_CPP_SRC_DIR: "{{.ROOT_DIR}}/src"
 
 tasks:
   clean:

--- a/taskfiles/lint-cmake.yaml
+++ b/taskfiles/lint-cmake.yaml
@@ -5,7 +5,6 @@ tasks:
     desc: "Runs the CMake linters."
     sources: &cmake_format_src_files
       - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
-      - "{{.G_YSTDLIB_CPP_SRC_DIR}}/.gersemirc"
       - "{{.ROOT_DIR}}/**/*.cmake"
       - "{{.ROOT_DIR}}/**/*.cmake.in"
       - "{{.ROOT_DIR}}/**/CMakeLists.txt"

--- a/taskfiles/lint-cpp.yaml
+++ b/taskfiles/lint-cpp.yaml
@@ -17,9 +17,9 @@ tasks:
     desc: "Runs the C++ linters that identify formatting issues."
     sources: &cpp_format_src_files
       - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
-      - "{{.G_YSTDLIB_CPP_SRC_DIR}}/**/*.cpp"
-      - "{{.G_YSTDLIB_CPP_SRC_DIR}}/**/*.h"
-      - "{{.G_YSTDLIB_CPP_SRC_DIR}}/**/*.hpp"
+      - "{{.G_CPP_SRC_DIR}}/**/*.cpp"
+      - "{{.G_CPP_SRC_DIR}}/**/*.h"
+      - "{{.G_CPP_SRC_DIR}}/**/*.hpp"
       - "{{.ROOT_DIR}}/.clang-format"
       - "{{.TASKFILE}}"
     deps:
@@ -52,16 +52,16 @@ tasks:
     # NOTE: clang-tidy does have the ability to fix some errors, but the fixes can be inaccurate.
     # When we eventually determine which errors can be safely fixed, we'll allow clang-tidy to
     # fix them.
-    desc: "Runs the C++ static analyzers. Only checks for warnings and violations."
     aliases:
       - "cpp-static-fix"
+    desc: "Runs the C++ static analyzers. Only checks for warnings and violations."
     sources:
       - "{{.G_CMAKE_CACHE}}"
       - "{{.G_COMPILE_COMMANDS_DB}}"
       - "{{.G_LINT_VENV_CHECKSUM_FILE}}"
-      - "{{.G_YSTDLIB_CPP_SRC_DIR}}/**/*.cpp"
-      - "{{.G_YSTDLIB_CPP_SRC_DIR}}/**/*.h"
-      - "{{.G_YSTDLIB_CPP_SRC_DIR}}/**/*.hpp"
+      - "{{.G_CPP_SRC_DIR}}/**/*.cpp"
+      - "{{.G_CPP_SRC_DIR}}/**/*.h"
+      - "{{.G_CPP_SRC_DIR}}/**/*.hpp"
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
     deps:

--- a/taskfiles/lint-venv.yaml
+++ b/taskfiles/lint-venv.yaml
@@ -1,0 +1,32 @@
+version: "3"
+
+tasks:
+  venv:
+    internal: true
+    vars:
+      CHECKSUM_FILE: "{{.G_LINT_VENV_CHECKSUM_FILE}}"
+      OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"
+    sources:
+      - "{{.ROOT_DIR}}/taskfile.yaml"
+      - "{{.TASKFILE}}"
+      - "{{.ROOT_DIR}}/lint-requirements.txt"
+    generates:
+      - "{{.CHECKSUM_FILE}}"
+    run: "once"
+    deps:
+      - ":init"
+      - task: ":utils:validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+    cmds:
+      - task: ":utils:create-venv"
+        vars:
+          LABEL: "lint"
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
+          REQUIREMENTS_FILE: "{{.ROOT_DIR}}/lint-requirements.txt"
+      # This command must be last
+      - task: ":utils:compute-checksum"
+        vars:
+          DATA_DIR: "{{.OUTPUT_DIR}}"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"

--- a/taskfiles/lint.yaml
+++ b/taskfiles/lint.yaml
@@ -7,15 +7,18 @@ includes:
   cpp:
     flatten: true
     taskfile: "./lint-cpp.yaml"
+  venv:
+    flatten: true
+    taskfile: "./lint-venv.yaml"
   yaml:
     flatten: true
     taskfile: "./lint-yaml.yaml"
 
 vars:
+  G_LINT_CPP_DIRS:
+    - "{{.G_CPP_SRC_DIR}}"
   G_LINT_VENV_DIR: "{{.G_BUILD_DIR}}/lint-venv"
   G_LINT_VENV_CHECKSUM_FILE: "{{.G_BUILD_DIR}}/lint#venv.md5"
-  G_LINT_CPP_DIRS:
-    - "{{.G_YSTDLIB_CPP_SRC_DIR}}"
 
 tasks:
   check:
@@ -31,33 +34,3 @@ tasks:
       - task: "cmake-fix"
       - task: "cpp-fix"
       - task: "yaml-fix"
-
-  venv:
-    internal: true
-    vars:
-      CHECKSUM_FILE: "{{.G_LINT_VENV_CHECKSUM_FILE}}"
-      OUTPUT_DIR: "{{.G_LINT_VENV_DIR}}"
-    sources:
-      - "{{.ROOT_DIR}}/taskfile.yaml"
-      - "{{.TASKFILE}}"
-      - "lint-requirements.txt"
-    generates:
-      - "{{.CHECKSUM_FILE}}"
-    run: "once"
-    deps:
-      - ":init"
-      - task: ":utils:validate-checksum"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-    cmds:
-      - task: ":utils:create-venv"
-        vars:
-          LABEL: "lint"
-          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
-          REQUIREMENTS_FILE: "lint-requirements.txt"
-      # This command must be last
-      - task: ":utils:compute-checksum"
-        vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.
Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
As the title says:
- Use absolute paths for `lint-requirements.txt`. Changes to this file was not picked up by the task `lint:venv`.
- Move `lint-venv` to a standalone file to avoid recreating venv unnecessarily due to unrelated changes to `taskfiles/lint.yaml`
- Rename `G_YSTDLIB_CPP_SRC_DIR` to `G_CPP_SRC_DIR` and update the path from `src/ystdlib` to `src` for broader C++ source file coverage.

Other minor changes:
- Reorder `alias` and `desc`
- Remove unnecessary gersemi config source from `lint:cmake-check/fix`

# Validation performed
- [x] Tested locally that all changes have taken effects.
