### PR TITLE
build: Add Catch2 dependency.

### DIFF
--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - "macos-latest"
+          #- "macos-latest"
           - "ubuntu-latest"
     runs-on: "${{matrix.os}}"
     steps:

--- a/.github/workflows/code-linting-checks.yaml
+++ b/.github/workflows/code-linting-checks.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os:
-          #- "macos-latest"
+          - "macos-latest"
           - "ubuntu-latest"
     runs-on: "${{matrix.os}}"
     steps:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -63,4 +63,4 @@ jobs:
 
       # TODO: Change the task to run all unittests once any unittest is added. Until then we check
       # that building the project succeeds.
-      - run: "task build:target"
+      - run: "task build:unittest"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os:
-          #- "macos-latest"
+          - "macos-latest"
           - "ubuntu-20.04"
           - "ubuntu-22.04"
           - "ubuntu-24.04"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - "macos-latest"
+          #- "macos-latest"
           - "ubuntu-20.04"
           - "ubuntu-22.04"
           - "ubuntu-24.04"

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -63,4 +63,4 @@ jobs:
 
       # TODO: Change the task to run all unittests once any unittest is added. Until then we check
       # that building the project succeeds.
-      - run: "task build:unittest"
+      - run: "task build:all"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,6 @@ project(YSTDLIB_CPP LANGUAGES CXX)
 
 set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")
 
-# find_package() uses upper-case <PACKAGENAME>_ROOT variables and prefers the paths specified by
-# these variables when looking for library packages.
-cmake_policy(SET CMP0144 NEW)
-
 # Enable exporting compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ project(YSTDLIB_CPP LANGUAGES CXX)
 
 set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")
 
+# find_package() uses upper-case <PACKAGENAME>_ROOT variables and prefers the paths specified by
+# these variables.
+cmake_policy(SET CMP0144 NEW)
+
 # Enable exporting compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,20 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
     FORCE
 )
 
+find_package(Catch2 3.8.0 REQUIRED)
+if (Catch2_FOUND)
+    message(STATUS "Found Catch2 ${Catch2_VERSION}.")
+else()
+    message(FATAL_ERROR "Could not find libraries for Catch2.")
+endif()
+
 # Import CMake helper functions
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/CMake)
 include(ystdlib-cpp-helpers)
 
 add_subdirectory(src/ystdlib)
 
-# Test dummy project
-add_executable(dummy)
-target_sources(dummy PRIVATE src/main.cpp)
-target_link_libraries(dummy PRIVATE ystdlib::testlib)
-target_compile_features(dummy PRIVATE cxx_std_20)
+add_executable(unitTest)
+target_sources(unitTest PRIVATE src/main.cpp)
+target_link_libraries(unitTest PRIVATE ystdlib::testlib Catch2::Catch2WithMain)
+target_compile_features(unitTest PRIVATE cxx_std_20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(YSTDLIB_CPP LANGUAGES CXX)
 set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")
 
 # find_package() uses upper-case <PACKAGENAME>_ROOT variables and prefers the paths specified by
-# these variables.
+# these variables when looking for library packages.
 cmake_policy(SET CMP0144 NEW)
 
 # Enable exporting compile commands

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
 )
 
 find_package(Catch2 3.8.0 REQUIRED)
-if (Catch2_FOUND)
+if(Catch2_FOUND)
     message(STATUS "Found Catch2 ${Catch2_VERSION}.")
 else()
     message(FATAL_ERROR "Could not find libraries for Catch2.")
@@ -26,5 +26,10 @@ add_subdirectory(src/ystdlib)
 
 add_executable(unitTest)
 target_sources(unitTest PRIVATE src/main.cpp)
-target_link_libraries(unitTest PRIVATE ystdlib::testlib Catch2::Catch2WithMain)
+target_link_libraries(
+    unitTest
+    PRIVATE
+        ystdlib::testlib
+        Catch2::Catch2WithMain
+)
 target_compile_features(unitTest PRIVATE cxx_std_20)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ git submodule update --init --recursive
 ## Building
 To build all targets in `ystdlib-cpp`:
 ```shell
-task build:target
+task build:all
 ```
 
 ## Linting

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,19 @@
+BasedOnStyle: "InheritParentConfig"
+
+IncludeCategories:
+  # NOTE: A header is grouped by first matching regex
+  # Library headers. Update when adding new libraries.
+  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
+  - Regex: "<(ystdlib)"
+    Priority: 3
+  - Regex: "<(catch2)"
+    Priority: 4
+  # C system headers
+  - Regex: "^<.+\\.h>"
+    Priority: 1
+  # C++ standard libraries
+  - Regex: "^<.+>"
+    Priority: 2
+  # Project headers
+  - Regex: "^\".+\""
+    Priority: 5

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,8 +1,8 @@
 BasedOnStyle: "InheritParentConfig"
 
 IncludeCategories:
-  # NOTE: A header is grouped by first matching regex
-  # Library headers. Update when adding new libraries.
+  # NOTE: A header is grouped by first matching regex library headers. Update when adding new 
+  # libraries.
   # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
   - Regex: "<(ystdlib)"
     Priority: 3

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,13 @@
-#include <catch2/catch_test_macros.hpp>
 #include <concepts>
+
 #include <ystdlib/testlib/hello.hpp>
+
+#include <catch2/catch_test_macros.hpp>
 
 namespace {
 template <typename T>
 requires std::integral<T>
+
 [[nodiscard]] auto square(T x) -> T {
     return x * x;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,7 @@
 #define CATCH_CONFIG_MAIN
 
+#include <catch2/catch_test_macros.hpp>
 #include <concepts>
-#include <iostream>
-
-#include <catch2/catch_all.hpp>
 #include <ystdlib/testlib/hello.hpp>
 
 namespace {
@@ -15,5 +13,5 @@ requires std::integral<T>
 };  // namespace
 
 TEST_CASE("dummy") {
-  REQUIRE((169 == square(ystdlib::testlib::hello().size())));
+    REQUIRE((169 == square(ystdlib::testlib::hello().size())));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,9 @@
+#define CATCH_CONFIG_MAIN
+
 #include <concepts>
 #include <iostream>
+
+#include <catch2/catch_all.hpp>
 #include <ystdlib/testlib/hello.hpp>
 
 namespace {
@@ -10,7 +14,6 @@ requires std::integral<T>
 }
 };  // namespace
 
-[[nodiscard]] auto main() -> int {
-    std::cout << square(ystdlib::testlib::hello().size()) << '\n';
-    return 0;
+TEST_CASE("dummy") {
+  REQUIRE((169 == square(ystdlib::testlib::hello().size())));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_MAIN
-
 #include <catch2/catch_test_macros.hpp>
 #include <concepts>
 #include <ystdlib/testlib/hello.hpp>

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -18,19 +18,6 @@ tasks:
     cmds:
       - "rm -rf '{{.G_BUILD_DIR}}'"
 
-  config-cmake-project:
-    internal: true
-    deps:
-      - "deps:install-all"
-    sources:
-      - "CMakeLists.txt"
-      - "{{.TASKFILE}}"
-    generates:
-      - "{{.G_CMAKE_CACHE}}"
-      - "{{.G_COMPILE_COMMANDS_DB}}"
-    cmds:
-      - "cmake -S '{{.ROOT_DIR}}' -B '{{.G_BUILD_DIR}}'"
-
   init:
     internal: true
     silent: true

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -10,6 +10,7 @@ vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
   G_CPP_SRC_DIR: "{{.ROOT_DIR}}/src"
+  G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
 
 tasks:
   clean:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -8,7 +8,6 @@ includes:
 
 vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
-  G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
   G_CPP_SRC_DIR: "{{.ROOT_DIR}}/src"
   G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -2,6 +2,7 @@ version: "3"
 
 includes:
   build: "./taskfiles/build.yaml"
+  deps: "./taskfiles/deps.yaml"
   lint: "./taskfiles/lint.yaml"
   utils: "tools/yscope-dev-utils/taskfiles/utils.yaml"
 
@@ -19,6 +20,8 @@ tasks:
 
   config-cmake-project:
     internal: true
+    deps:
+      - "deps:install-all"
     sources:
       - "CMakeLists.txt"
       - "{{.TASKFILE}}"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -3,7 +3,7 @@ version: "3"
 includes:
   build: "./taskfiles/build.yaml"
   lint: "./taskfiles/lint.yaml"
-  utils: "tools/yscope-dev-utils/taskfiles/utils.yml"
+  utils: "tools/yscope-dev-utils/taskfiles/utils.yaml"
 
 vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -8,7 +8,6 @@ includes:
 
 vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
-  G_CMAKE_CACHE: "{{.G_BUILD_DIR}}/CMakeCache.txt"
   G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
   G_CPP_SRC_DIR: "{{.ROOT_DIR}}/src"
 

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -1,63 +1,31 @@
 version: "3"
 
 vars:
-  G_BUILD_CONF_ARGS_DEPS_INSTALL_PREFIXES: >-
-    -DCatch2_ROOT={{.G_DEPS_DIR}}/Catch2-install
-  G_BUILD_CONF_ARGS: >-
-    {{.G_BUILD_CONF_ARGS_DEPS_INSTALL_PREFIXES}}
+  G_CMAKE_CONF_ARGS:
+    - "-DCatch2_ROOT={{.G_DEPS_DIR}}/Catch2-install"
 
 tasks:
-  target:
-    desc: "Builds ystdlib-cpp."
+  unittest:
+    desc: "Builds and runs ystdlib-cpp's unittest."
     deps:
       - ":deps:install-all"
     cmds:
-      - task: ":utils:cmake-config-and-build"
+      - task: ":utils:cmake-generate"
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
-          CONF_ARGS: "{{.G_BUILD_CONF_ARGS}}"
-          JOBS: "{{numCPU}}"
+          EXTRA_ARGS:
+            ref: ".G_CMAKE_CONF_ARGS"
           SOURCE_DIR: "{{.ROOT_DIR}}"
-      # TODO: move this into a separate task
-      - "{{.G_BUILD_DIR}}/unitTest"
+      - task: ":utils:cmake-build"
+        vars:
+          BUILD_DIR: "{{.G_BUILD_DIR}}"
+          JOBS: "{{numCPU}}"
+          TARGETS:
+            - "unitTest"
 
-  # TODO: move this into yscope-dev-utils
   clean:
     desc: "Removes all built artifacts."
     deps:
-      - task: ":build:cmake-config"
+      - task: ":utils:cmake-clean"
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
-          CONF_ARGS: "{{.G_BUILD_CONF_ARGS}}"
-          SOURCE_DIR: "{{.ROOT_DIR}}"
-    cmds:
-      - >-
-        cmake
-        --build "{{.G_BUILD_DIR}}"
-        --parallel {{numCPU}}
-        --target clean
-
-  # TODO: move this into yscope-dev-utils
-  cmake-config:
-    internal: true
-    label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}-{{.CONF_ARGS}}"
-    vars:
-      CONF_ARGS: >-
-        {{default "" .CONF_ARGS}}
-    requires:
-      vars:
-        - "BUILD_DIR"
-        - "SOURCE_DIR"
-    sources:
-      - "{{.SOURCE_DIR}}/CMakeLists.txt"
-    generates:
-      - "{{.BUILD_DIR}}/CMakeCache.txt"
-      - "{{.BUILD_DIR}}/compile_commands.json"
-    deps:
-      - ":deps:install-all"
-    cmds:
-      - >-
-        cmake
-        -S "{{.SOURCE_DIR}}"
-        -B "{{.BUILD_DIR}}"
-        {{.CONF_ARGS}}

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -17,6 +17,13 @@ tasks:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
           JOBS: "{{numCPU}}"
 
+  clean:
+    desc: "Removes all built artifacts."
+    deps:
+      - task: ":utils:cmake-clean"
+        vars:
+          BUILD_DIR: "{{.G_BUILD_DIR}}"
+
   cmake-generate:
     internal: true
     deps:
@@ -35,10 +42,3 @@ tasks:
           EXTRA_ARGS:
             ref: ".G_CMAKE_CONF_ARGS"
           SOURCE_DIR: "{{.ROOT_DIR}}"
-
-  clean:
-    desc: "Removes all built artifacts."
-    deps:
-      - task: ":utils:cmake-clean"
-        vars:
-          BUILD_DIR: "{{.G_BUILD_DIR}}"

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -1,14 +1,34 @@
 version: "3"
 
 vars:
+  G_CMAKE_CACHE: "{{.G_BUILD_DIR}}/CMakeCache.txt"
   G_CMAKE_CONF_ARGS:
     - "-DCatch2_ROOT={{.G_DEPS_DIR}}/Catch2-install"
+  G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
 
 tasks:
   unittest:
     desc: "Builds and runs ystdlib-cpp's unittest."
     deps:
+      - "cmake-generate"
+    cmds:
+      - task: ":utils:cmake-build"
+        vars:
+          BUILD_DIR: "{{.G_BUILD_DIR}}"
+          JOBS: "{{numCPU}}"
+          TARGETS:
+            - "unitTest"
+
+  cmake-generate:
+    internal: true
+    deps:
       - ":deps:install-all"
+    sources:
+      - "{{.ROOT_DIR}}/CMakeLists.txt"
+      - "{{.TASKFILE}}"
+    generates:
+      - "{{.G_CMAKE_CACHE}}"
+      - "{{.G_COMPILE_COMMANDS_DB}}"
     cmds:
       - task: ":utils:cmake-generate"
         vars:
@@ -16,12 +36,6 @@ tasks:
           EXTRA_ARGS:
             ref: ".G_CMAKE_CONF_ARGS"
           SOURCE_DIR: "{{.ROOT_DIR}}"
-      - task: ":utils:cmake-build"
-        vars:
-          BUILD_DIR: "{{.G_BUILD_DIR}}"
-          JOBS: "{{numCPU}}"
-          TARGETS:
-            - "unitTest"
 
   clean:
     desc: "Removes all built artifacts."

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -1,21 +1,35 @@
 version: "3"
 
+vars:
+  G_BUILD_CONF_ARGS_DEPS_INSTALL_PREFIXES: >-
+    -DCatch2_ROOT={{.G_DEPS_DIR}}/Catch2-install
+  G_BUILD_CONF_ARGS: >-
+    {{.G_BUILD_CONF_ARGS_DEPS_INSTALL_PREFIXES}}
+
 tasks:
   target:
     desc: "Builds ystdlib-cpp."
+    deps:
+      - ":deps:install-all"
     cmds:
       - task: ":utils:cmake-config-and-build"
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
-          SOURCE_DIR: "{{.ROOT_DIR}}"
-          CONF_ARGS: >-
-            -DCatch2_ROOT="{{.G_DEPS_DIR}}/Catch2-install"
+          CONF_ARGS: "{{.G_BUILD_CONF_ARGS}}"
           JOBS: "{{numCPU}}"
+          SOURCE_DIR: "{{.ROOT_DIR}}"
+      # TODO: move this into a separate task
+      - "{{.G_BUILD_DIR}}/unitTest"
 
+  # TODO: move this into yscope-dev-utils
   clean:
     desc: "Removes all built artifacts."
     deps:
-      - ":config-cmake-project"
+      - task: ":build:cmake-config"
+        vars:
+          BUILD_DIR: "{{.G_BUILD_DIR}}"
+          CONF_ARGS: "{{.G_BUILD_CONF_ARGS}}"
+          SOURCE_DIR: "{{.ROOT_DIR}}"
     cmds:
       - >-
         cmake
@@ -23,13 +37,27 @@ tasks:
         --parallel {{numCPU}}
         --target clean
 
-  config-cmake-project:
+  # TODO: move this into yscope-dev-utils
+  cmake-config:
     internal: true
+    label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}-{{.CONF_ARGS}}"
+    vars:
+      CONF_ARGS: >-
+        {{default "" .CONF_ARGS}}
+    requires:
+      vars:
+        - "BUILD_DIR"
+        - "SOURCE_DIR"
     sources:
-      - "CMakeLists.txt"
-      - "{{.TASKFILE}}"
+      - "{{.SOURCE_DIR}}/CMakeLists.txt"
     generates:
-      - "{{.G_CMAKE_CACHE}}"
-      - "{{.G_COMPILE_COMMANDS_DB}}"
+      - "{{.BUILD_DIR}}/CMakeCache.txt"
+      - "{{.BUILD_DIR}}/compile_commands.json"
+    deps:
+      - ":deps:install-all"
     cmds:
-      - "cmake -S '{{.ROOT_DIR}}' -B '{{.G_BUILD_DIR}}'"
+      - >-
+        cmake
+        -S "{{.SOURCE_DIR}}"
+        -B "{{.BUILD_DIR}}"
+        {{.CONF_ARGS}}

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -15,7 +15,6 @@ tasks:
       - task: ":utils:cmake-build"
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
-          JOBS: "{{numCPU}}"
 
   clean:
     desc: "Removes all built artifacts."
@@ -28,9 +27,6 @@ tasks:
     internal: true
     deps:
       - ":deps:install-all"
-    generates:
-      - "{{.G_CMAKE_CACHE}}"
-      - "{{.G_COMPILE_COMMANDS_DB}}"
     run: "once"
     cmds:
       - task: ":utils:cmake-generate"

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -7,8 +7,8 @@ vars:
   G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
 
 tasks:
-  unittest:
-    desc: "Builds and runs ystdlib-cpp's unittest."
+  all:
+    desc: "Builds ystdlib-cpp."
     deps:
       - "cmake-generate"
     cmds:
@@ -16,8 +16,6 @@ tasks:
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
           JOBS: "{{numCPU}}"
-          TARGETS:
-            - "unitTest"
 
   cmake-generate:
     internal: true
@@ -29,6 +27,7 @@ tasks:
     generates:
       - "{{.G_CMAKE_CACHE}}"
       - "{{.G_COMPILE_COMMANDS_DB}}"
+    run: "once"
     cmds:
       - task: ":utils:cmake-generate"
         vars:

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -3,22 +3,17 @@ version: "3"
 tasks:
   target:
     desc: "Builds ystdlib-cpp."
-    vars:
-      TARGETS:
-        ref: "default (list \"all\") .TARGETS"
-    deps:
-      - ":config-cmake-project"
     cmds:
-      - >-
-        cmake
-        --build "{{.G_BUILD_DIR}}"
-        --parallel {{numCPU}}
-        --target {{range .TARGETS}}{{.}} {{end}}
+      - task: ":utils:cmake-config-and-build"
+        vars:
+          BUILD_DIR: "{{.G_BUILD_DIR}}"
+          SOURCE_DIR: "{{.ROOT_DIR}}"
+          CONF_ARGS: >-
+            -DCatch2_ROOT="{{.G_DEPS_DIR}}/Catch2-install"
+          JOBS: "{{numCPU}}"
 
   clean:
     desc: "Removes all built artifacts."
-    deps:
-      - ":config-cmake-project"
     cmds:
       - >-
         cmake

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -3,7 +3,7 @@ version: "3"
 vars:
   G_CMAKE_CACHE: "{{.G_BUILD_DIR}}/CMakeCache.txt"
   G_CMAKE_CONF_ARGS:
-    - "-DCatch2_ROOT={{.G_DEPS_DIR}}/Catch2-install"
+    - "-DCatch2_ROOT={{.G_DEPS_DIR}}/Catch2/Catch2-install"
   G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
 
 tasks:

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -28,9 +28,6 @@ tasks:
     internal: true
     deps:
       - ":deps:install-all"
-    sources:
-      - "{{.ROOT_DIR}}/CMakeLists.txt"
-      - "{{.TASKFILE}}"
     generates:
       - "{{.G_CMAKE_CACHE}}"
       - "{{.G_COMPILE_COMMANDS_DB}}"

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -14,9 +14,22 @@ tasks:
 
   clean:
     desc: "Removes all built artifacts."
+    deps:
+      - ":config-cmake-project"
     cmds:
       - >-
         cmake
         --build "{{.G_BUILD_DIR}}"
         --parallel {{numCPU}}
         --target clean
+
+  config-cmake-project:
+    internal: true
+    sources:
+      - "CMakeLists.txt"
+      - "{{.TASKFILE}}"
+    generates:
+      - "{{.G_CMAKE_CACHE}}"
+      - "{{.G_COMPILE_COMMANDS_DB}}"
+    cmds:
+      - "cmake -S '{{.ROOT_DIR}}' -B '{{.G_BUILD_DIR}}'"

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -10,7 +10,7 @@ tasks:
   all:
     desc: "Builds ystdlib-cpp."
     deps:
-      - "cmake-generate"
+      - "init"
     cmds:
       - task: ":utils:cmake-build"
         vars:
@@ -23,7 +23,7 @@ tasks:
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
 
-  cmake-generate:
+  init:
     internal: true
     deps:
       - ":deps:install-all"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -11,13 +11,7 @@ tasks:
     vars:
       NAME: "Catch2"
       WORK_DIR: "{{.G_DEPS_DIR}}/{{.NAME}}"
-    sources:
-      - "{{.TASKFILE}}"
-      - "{{.WORK_DIR}}/{{.NAME}}-install/**/*"
     run: "once"
-    status:
-      - "test -d {{.WORK_DIR}}/{{.NAME}}-install"
-      - "test -f {{.WORK_DIR}}/{{.NAME}}-src.md5"
     cmds:
       - task: ":utils:cmake-install-remote-tar"
         vars:
@@ -25,4 +19,3 @@ tasks:
           WORK_DIR: "{{.WORK_DIR}}"
           FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
           URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"
-          JOBS: "{{numCPU}}"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -10,7 +10,7 @@ tasks:
     internal: true
     sources:
       - "{{.G_DEPS_DIR}}/Catch2-install/*"
-      - "{{.G_DEPS_DIR}}/Catch2-src.md5"
+      - "{{.TASKFILE}}"
     generates:
       - "{{.G_DEPS_DIR}}/Catch2-src.md5"
     cmds:

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -1,0 +1,58 @@
+version: "3"
+
+vars:
+  G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
+  G_DEPS_RELEASES_JSON: >-
+    {
+      "Catch2": "v3.8.0"
+    }
+  G_DEPS_RELEASES:
+    ref: 'fromJson .G_DEPS_RELEASES_JSON'
+
+tasks:
+  install-all:
+    desc: "Install all dependencies required by ystdlib-cpp."
+    deps:
+      - task: "install-dep"
+        vars:
+          NAME: "Catch2"
+          ORG: "catchorg"
+          RELEASE: "{{.G_DEPS_RELEASES.Catch2}}"
+          SOURCE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
+
+  install-dep:
+    internal: true
+    label: "install-{{.NAME}}-{{.VERSION}}-{{.CONF_ARGS}}"
+    vars:
+      BUILD_DIR: >-
+        {{default (printf "%s/%s-build" .G_DEPS_DIR .NAME) .BUILD_DIR}}
+      CONF_ARGS: >-
+        {{default "" .CONF_ARGS}}
+      INSTALL_PREFIX: >-
+        {{default (printf "%s/%s-install" .G_DEPS_DIR .NAME) .INSTALL_PREFIX}}
+      SOURCE_DIR: >-
+        {{default (printf "%s/%s-src" .G_DEPS_DIR .NAME) .SOURCE_DIR}}
+    requires:
+      vars:
+        - "NAME"
+        - "ORG"
+        - "RELEASE"
+        - "SOURCE_SHA256"
+    sources:
+      - "{{.G_DEPS_DIR}}/{{.NAME}}-src.md5"
+    cmds:
+      - task: ":utils:download-and-extract-tar"
+        vars:
+          FILE_SHA256: "{{.SOURCE_SHA256}}"
+          OUTPUT_DIR: "{{.SOURCE_DIR}}"
+          URL: >-
+            {{printf "https://github.com/%s/%s/archive/refs/tags/%s.tar.gz" .ORG .NAME .RELEASE}}
+      - task: ":utils:cmake-config-and-build"
+        vars:
+          BUILD_DIR: "{{.BUILD_DIR}}"
+          CONF_ARGS: "{{.CONF_ARGS}}"
+          SOURCE_DIR: "{{.SOURCE_DIR}}"
+      - task: ":utils:cmake-install"
+        vars:
+          BUILD_DIR: "{{.BUILD_DIR}}"
+          INSTALL_PREFIX: "{{.INSTALL_PREFIX}}"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -1,60 +1,23 @@
 version: "3"
 
-vars:
-  G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
-  G_DEPS_RELEASES_JSON: >-
-    {
-      "Catch2": "v3.8.0"
-    }
-  G_DEPS_RELEASES:
-    ref: "fromJson .G_DEPS_RELEASES_JSON"
-
 tasks:
   install-all:
     desc: "Install all dependencies required by ystdlib-cpp."
     deps:
-      - task: "install-dep"
+      - "install-Catch2"
+
+  install-Catch2:
+    internal: true
+    sources:
+      - "{{.G_DEPS_DIR}}/Catch2-install/*"
+      - "{{.G_DEPS_DIR}}/Catch2-src.md5"
+    generates:
+      - "{{.G_DEPS_DIR}}/Catch2-src.md5"
+    cmds:
+      - task: ":utils:cmake-install-remote-tar"
         vars:
           NAME: "Catch2"
-          ORG: "catchorg"
-          RELEASE: "{{.G_DEPS_RELEASES.Catch2}}"
-          SOURCE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
-
-  install-dep:
-    internal: true
-    label: "install-{{.NAME}}-{{.RELEASE}}-{{.CONF_ARGS}}"
-    vars:
-      BUILD_DIR: >-
-        {{default (printf "%s/%s-build" .G_DEPS_DIR .NAME) .BUILD_DIR}}
-      CONF_ARGS: >-
-        {{default "" .CONF_ARGS}}
-      INSTALL_PREFIX: >-
-        {{default (printf "%s/%s-install" .G_DEPS_DIR .NAME) .INSTALL_PREFIX}}
-      SOURCE_DIR: >-
-        {{default (printf "%s/%s-src" .G_DEPS_DIR .NAME) .SOURCE_DIR}}
-    requires:
-      vars:
-        - "NAME"
-        - "ORG"
-        - "RELEASE"
-        - "SOURCE_SHA256"
-    sources:
-      - "{{.G_DEPS_DIR}}/{{.NAME}}-src.md5"
-    generates:
-      - "{{.G_DEPS_DIR}}/{{.NAME}}-src.md5"
-    cmds:
-      - task: ":utils:download-and-extract-tar"
-        vars:
-          FILE_SHA256: "{{.SOURCE_SHA256}}"
-          OUTPUT_DIR: "{{.SOURCE_DIR}}"
-          URL: >-
-            {{printf "https://github.com/%s/%s/archive/refs/tags/%s.tar.gz" .ORG .NAME .RELEASE}}
-      - task: ":utils:cmake-config-and-build"
-        vars:
-          BUILD_DIR: "{{.BUILD_DIR}}"
-          CONF_ARGS: "{{.CONF_ARGS}}"
-          SOURCE_DIR: "{{.SOURCE_DIR}}"
-      - task: ":utils:cmake-install"
-        vars:
-          BUILD_DIR: "{{.BUILD_DIR}}"
-          INSTALL_PREFIX: "{{.INSTALL_PREFIX}}"
+          WORK_DIR: "{{.G_DEPS_DIR}}"
+          FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
+          URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"
+          JOBS: "{{numCPU}}"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -16,8 +16,8 @@ tasks:
       - "{{.WORK_DIR}}/{{.NAME}}-install/**/*"
     run: "once"
     status:
-      - test -d "{{.WORK_DIR}}/{{.NAME}}-install"
-      - test -f "{{.WORK_DIR}}/{{.NAME}}-src.md5"
+      - "test -d {{.WORK_DIR}}/{{.NAME}}-install"
+      - "test -f {{.WORK_DIR}}/{{.NAME}}-src.md5"
     cmds:
       - task: ":utils:cmake-install-remote-tar"
         vars:

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -7,7 +7,7 @@ vars:
       "Catch2": "v3.8.0"
     }
   G_DEPS_RELEASES:
-    ref: 'fromJson .G_DEPS_RELEASES_JSON'
+    ref: "fromJson .G_DEPS_RELEASES_JSON"
 
 tasks:
   install-all:

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -22,7 +22,7 @@ tasks:
 
   install-dep:
     internal: true
-    label: "install-{{.NAME}}-{{.VERSION}}-{{.CONF_ARGS}}"
+    label: "install-{{.NAME}}-{{.RELEASE}}-{{.CONF_ARGS}}"
     vars:
       BUILD_DIR: >-
         {{default (printf "%s/%s-build" .G_DEPS_DIR .NAME) .BUILD_DIR}}
@@ -39,6 +39,8 @@ tasks:
         - "RELEASE"
         - "SOURCE_SHA256"
     sources:
+      - "{{.G_DEPS_DIR}}/{{.NAME}}-src.md5"
+    generates:
       - "{{.G_DEPS_DIR}}/{{.NAME}}-src.md5"
     cmds:
       - task: ":utils:download-and-extract-tar"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -8,16 +8,21 @@ tasks:
 
   install-Catch2:
     internal: true
+    vars:
+      NAME: "Catch2"
+      WORK_DIR: "{{.G_DEPS_DIR}}/{{.NAME}}"
     sources:
-      - "{{.G_DEPS_DIR}}/Catch2-install/*"
       - "{{.TASKFILE}}"
-    generates:
-      - "{{.G_DEPS_DIR}}/Catch2-src.md5"
+      - "{{.WORK_DIR}}/{{.NAME}}-install/**/*"
+    run: "once"
+    status:
+      - test -d "{{.WORK_DIR}}/{{.NAME}}-install"
+      - test -f "{{.WORK_DIR}}/{{.NAME}}-src.md5"
     cmds:
       - task: ":utils:cmake-install-remote-tar"
         vars:
-          NAME: "Catch2"
-          WORK_DIR: "{{.G_DEPS_DIR}}"
+          NAME: "{{.NAME}}"
+          WORK_DIR: "{{.WORK_DIR}}"
           FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
           URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"
           JOBS: "{{numCPU}}"

--- a/taskfiles/lint-cpp.yaml
+++ b/taskfiles/lint-cpp.yaml
@@ -65,7 +65,7 @@ tasks:
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
     deps:
-      - ":config-cmake-project"
+      - ":build:config-cmake-project"
       - "cpp-configs"
       - "venv"
     cmds:

--- a/taskfiles/lint-cpp.yaml
+++ b/taskfiles/lint-cpp.yaml
@@ -65,10 +65,11 @@ tasks:
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
     deps:
-      - task: ":build:cmake-config"
+      - task: ":utils:cmake-generate"
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
-          CONF_ARGS: "{{.G_BUILD_CONF_ARGS}}"
+          EXTRA_ARGS:
+            ref: ".G_CMAKE_CONF_ARGS"
           SOURCE_DIR: "{{.ROOT_DIR}}"
       - "cpp-configs"
       - "venv"

--- a/taskfiles/lint-cpp.yaml
+++ b/taskfiles/lint-cpp.yaml
@@ -65,7 +65,7 @@ tasks:
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
     deps:
-      - ":build:cmake-generate"
+      - ":build:init"
       - "cpp-configs"
       - "venv"
     cmds:

--- a/taskfiles/lint-cpp.yaml
+++ b/taskfiles/lint-cpp.yaml
@@ -65,7 +65,11 @@ tasks:
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
     deps:
-      - ":build:config-cmake-project"
+      - task: ":build:cmake-config"
+        vars:
+          BUILD_DIR: "{{.G_BUILD_DIR}}"
+          CONF_ARGS: "{{.G_BUILD_CONF_ARGS}}"
+          SOURCE_DIR: "{{.ROOT_DIR}}"
       - "cpp-configs"
       - "venv"
     cmds:

--- a/taskfiles/lint-cpp.yaml
+++ b/taskfiles/lint-cpp.yaml
@@ -65,12 +65,7 @@ tasks:
       - "{{.ROOT_DIR}}/.clang-tidy"
       - "{{.TASKFILE}}"
     deps:
-      - task: ":utils:cmake-generate"
-        vars:
-          BUILD_DIR: "{{.G_BUILD_DIR}}"
-          EXTRA_ARGS:
-            ref: ".G_CMAKE_CONF_ARGS"
-          SOURCE_DIR: "{{.ROOT_DIR}}"
+      - ":build:cmake-generate"
       - "cpp-configs"
       - "venv"
     cmds:

--- a/taskfiles/lint-venv.yaml
+++ b/taskfiles/lint-venv.yaml
@@ -18,7 +18,7 @@ tasks:
       - task: ":utils:validate-checksum"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_DIR: "{{.OUTPUT_DIR}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - task: ":utils:create-venv"
         vars:
@@ -28,5 +28,5 @@ tasks:
       # This command must be last
       - task: ":utils:compute-checksum"
         vars:
-          DATA_DIR: "{{.OUTPUT_DIR}}"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]

--- a/taskfiles/lint-yaml.yaml
+++ b/taskfiles/lint-yaml.yaml
@@ -12,7 +12,6 @@ tasks:
       - "{{.ROOT_DIR}}/**/*.yml"
       - "{{.TASKFILE}}"
       - exclude: "{{.ROOT_DIR}}/**/build/*"
-      - exclude: "{{.ROOT_DIR}}/**/submodules/*"
       - exclude: "{{.ROOT_DIR}}/**/tools/*"
     dir: "{{.ROOT_DIR}}"
     deps:
@@ -21,7 +20,7 @@ tasks:
       - |-
         . "{{.G_LINT_VENV_DIR}}/bin/activate"
         find . \
-          \( -path '**/build' -o -path '**/submodules' -o -path '**/tools' \) -prune -o \
+          \( -path '**/build' -o -path '**/tools' \) -prune -o \
           \( -iname "*.yaml" -o -iname "*.yml" \) \
           -print0 | \
             xargs -0 yamllint \


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

**highest-order-bit:** task `build:all` ensures that all dependencies are installed before building `ystdlib-cpp` itself, and it should trigger a re-run whenever there's a dependency change.

- Download and install `Catch2` dependency with the newest cmake and remote tasks in  `yscope-dev-utils`.
- Replace the current cmake config and build tasks in `ystdlib-cpp` with the newest versions in `yscope-dev-utils`.
- Change the dummy target to a `Catch2` unit test target.
- Remove `submodules` as a potential folder to exclude when linting yaml files in `ystdlib-cpp`. Now every non-project file resides in `build` except for `yscope-dev-utils`.
- Update the `lint:venv` task to comply with the arglist of new checksum tasks in `yscope-dev-utils`.
- Add `.clang-format` in `ystdlib-cpp/src` for header includes reorder rules.

As discussed offline, we are going to resolve the unnecessarily long dependency installation logs in the future.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
* [X] The new unit test target builds and runs succcessfully.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
