### PR TITLE
build: Generate CMake settings file containing dependency installation directories to replace specification through CLI options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ option(BUILD_TESTING "If ON, unit tests will be built." ON)
 # Import CMake helper functions
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/CMake)
 
+include(build/deps/settings.cmake)
+
 if(BUILD_TESTING)
     find_package(Catch2 3.8.0 REQUIRED)
     if(Catch2_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,10 @@ option(BUILD_TESTING "If ON, unit tests will be built." ON)
 # Import CMake helper functions
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/CMake)
 
-include(build/deps/settings.cmake)
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # Include dependency settings if the project isn't being included as a subproject.
+    include(build/deps/settings.cmake)
+endif()
 
 if(BUILD_TESTING)
     find_package(Catch2 3.8.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/CMake)
 
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     # Include dependency settings if the project isn't being included as a subproject.
-    include(build/deps/settings.cmake)
+    # NOTE: We mark the file optional because if the user happens to have the dependencies
+    # installed, this file is not necessary.
+    include(build/deps/settings.cmake OPTIONAL)
 endif()
 
 if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Initialize and update submodules:
 git submodule update --init --recursive
 ```
 
+Install any necessary dependencies from source:
+```shell
+task deps:install-all
+```
+
 ## Building
 To build all targets:
 ```shell

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Initialize and update submodules:
 git submodule update --init --recursive
 ```
 
-Install any necessary dependencies from source:
+If you want to open the project in an IDE, run the following command to install any necessary
+dependencies from source:
 ```shell
 task deps:install-all
 ```

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -10,6 +10,10 @@ vars:
   G_BUILD_DIR: "{{.ROOT_DIR}}/build"
   G_CPP_SRC_DIR: "{{.ROOT_DIR}}/src"
   G_DEPS_DIR: "{{.G_BUILD_DIR}}/deps"
+
+  # This should be kept in-sync with its usage in CMakeLists.txt
+  G_DEPS_CMAKE_SETTINGS_FILE: "{{.G_DEPS_DIR}}/settings.cmake"
+
   G_TEST_BIN_DIR: "{{.G_BUILD_DIR}}/testbin"
   G_TEST_TARGET_SUFFIXES:
     - "all"

--- a/taskfiles/build.yaml
+++ b/taskfiles/build.yaml
@@ -2,8 +2,6 @@ version: "3"
 
 vars:
   G_CMAKE_CACHE: "{{.G_BUILD_DIR}}/CMakeCache.txt"
-  G_CMAKE_CONF_ARGS:
-    - "-DCatch2_ROOT={{.G_DEPS_DIR}}/Catch2/Catch2-install"
   G_COMPILE_COMMANDS_DB: "{{.G_BUILD_DIR}}/compile_commands.json"
 
 tasks:
@@ -64,6 +62,4 @@ tasks:
       - task: ":utils:cmake-generate"
         vars:
           BUILD_DIR: "{{.G_BUILD_DIR}}"
-          EXTRA_ARGS:
-            ref: ".G_CMAKE_CONF_ARGS"
           SOURCE_DIR: "{{.ROOT_DIR}}"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -1,21 +1,28 @@
 version: "3"
 
+vars:
+  G_CATCH2_LIB_NAME: "Catch2"
+  G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIBNAME}}"
+
 tasks:
   install-all:
     desc: "Install all dependencies required by ystdlib-cpp."
     deps:
       - "install-Catch2"
+    cmds:
+      - "rm -f '{{.G_DEPS_CMAKE_SETTINGS_FILE}}'"
+      - >-
+        echo "set(
+        {{.G_CATCH2_LIBNAME}}_ROOT \"{{.G_CATCH2_WORK_DIR}}/{{.G_CATCH2_LIB_NAME}}-install\"
+        )" >> "{{.G_DEPS_CMAKE_SETTINGS_FILE}}"
 
   install-Catch2:
     internal: true
-    vars:
-      NAME: "Catch2"
-      WORK_DIR: "{{.G_DEPS_DIR}}/{{.NAME}}"
     run: "once"
     cmds:
       - task: ":utils:cmake-install-remote-tar"
         vars:
-          NAME: "{{.NAME}}"
-          WORK_DIR: "{{.WORK_DIR}}"
+          NAME: "{{.G_CATCH2_LIB_NAME}}"
+          WORK_DIR: "{{.G_CATCH2_WORK_DIR}}"
           FILE_SHA256: "1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087"
           URL: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -13,7 +13,7 @@ tasks:
       - "rm -f '{{.G_DEPS_CMAKE_SETTINGS_FILE}}'"
       - >-
         echo "set(
-        {{.G_CATCH2_LIBNAME}}_ROOT \"{{.G_CATCH2_WORK_DIR}}/{{.G_CATCH2_LIB_NAME}}-install\"
+        {{.G_CATCH2_LIB_NAME}}_ROOT \"{{.G_CATCH2_WORK_DIR}}/{{.G_CATCH2_LIB_NAME}}-install\"
         )" >> "{{.G_DEPS_CMAKE_SETTINGS_FILE}}"
 
   install-Catch2:

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -3,6 +3,7 @@ version: "3"
 vars:
   G_CATCH2_LIB_NAME: "Catch2"
   G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIB_NAME}}"
+
 tasks:
   install-all:
     desc: "Install all dependencies required by ystdlib-cpp."

--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -2,8 +2,7 @@ version: "3"
 
 vars:
   G_CATCH2_LIB_NAME: "Catch2"
-  G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIBNAME}}"
-
+  G_CATCH2_WORK_DIR: "{{.G_DEPS_DIR}}/{{.G_CATCH2_LIB_NAME}}"
 tasks:
   install-all:
     desc: "Install all dependencies required by ystdlib-cpp."


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Currently, the install directory of source dependencies (e.g., `Catch2_ROOT`) needs to be specified through CMake flags on the command line. Although we have `task`s to automate building, it's still tedious to maintain these [CMake flags](https://github.com/y-scope/ystdlib-cpp/blob/main/taskfiles/build.yaml#L6) for every library.

Moreover, the flags need to be specified when opening the project in an IDE.

This PR changes the source dependency installation tasks to generate a CMake settings file that contains all the source dependencies' installation directories. This settings file is then included in the main CMake project, making it unnecessary to specify the installation directories through CMake flags.

This PR also updates the README to indicate that IDE users need to run `task deps:install-all`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* CI passed.
* After cloning the project on a machine without Catch2 installed, and running `task deps:install-all`, the project could be opened in CLion without errors.
* After cloning the project on a machine with Catch2 installed, the project could be opened in CLion without errors.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated setup instructions to guide users in opening the project in an Integrated Development Environment and installing dependencies with a simple command.
- **Chores**
	- Enhanced dependency management and streamlined build process configurations to ensure a smoother project setup.
	- Simplified third-party library installation steps for improved consistency.
	- Added new global variables for better configuration management of the Catch2 library installation.
	- Removed unnecessary variables to simplify task execution parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->