### PR TITLE
build(cmake): Require compiler versions that support the C++20 features necessary for compiling `ystdlib-cpp`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(YSTDLIB_CPP LANGUAGES CXX)
 
 set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")
 
-# Force minimum compiler versions to support full C++20 features
+# Require compiler versions that support the necessary C++20 features
 if("AppleClang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
 elseif("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ endif()
 if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "${CMAKE_CXX_COMPILER_MIN_VERSION}")
     message(
         FATAL_ERROR
-        "${CMAKE_CXX_COMPILER_ID} version must be at least ${CMAKE_CXX_COMPILER_MIN_VERSION}!"
+        "${CMAKE_CXX_COMPILER_ID} version ${CMAKE_CXX_COMPILER_VERSION} is too low. Must be at \
+        least ${CMAKE_CXX_COMPILER_MIN_VERSION}."
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,21 @@
 cmake_minimum_required(VERSION 3.16.3)
+
+# Force minimum compiler versions to support full C++20 features
+set(CMAKE_CXX_COMPILER_MIN_VERSION "")
+if("AppleClang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+    set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
+elseif("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+    set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
+elseif("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+    set(CMAKE_CXX_COMPILER_MIN_VERSION "11.4")
+endif()
+if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS ${CMAKE_CXX_COMPILER_MIN_VERSION})
+    message(
+        FATAL_ERROR
+        "${CMAKE_CXX_COMPILER_ID} version must be at least ${CMAKE_CXX_COMPILER_MIN_VERSION}!"
+    )
+endif()
+
 project(YSTDLIB_CPP LANGUAGES CXX)
 
 set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,24 +4,24 @@ project(YSTDLIB_CPP LANGUAGES CXX)
 
 set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")
 
-# Require compiler versions that support the necessary C++20 features
+# Require compiler versions that support the C++20 features necessary for compiling ystdlib-cpp
 if("AppleClang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-    set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
+    set(YSTDLIB_CPP_CMAKE_CXX_COMPILER_MIN_VERSION "16")
 elseif("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-    set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
+    set(YSTDLIB_CPP_CMAKE_CXX_COMPILER_MIN_VERSION "16")
 elseif("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-    set(CMAKE_CXX_COMPILER_MIN_VERSION "11.4")
+    set(YSTDLIB_CPP_CMAKE_CXX_COMPILER_MIN_VERSION "11")
 else()
     message(
         FATAL_ERROR
         "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}. Please use AppleClang, Clang, or GNU."
     )
 endif()
-if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "${CMAKE_CXX_COMPILER_MIN_VERSION}")
+if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "${YSTDLIB_CPP_CMAKE_CXX_COMPILER_MIN_VERSION}")
     message(
         FATAL_ERROR
         "${CMAKE_CXX_COMPILER_ID} version ${CMAKE_CXX_COMPILER_VERSION} is too low. Must be at \
-        least ${CMAKE_CXX_COMPILER_MIN_VERSION}."
+        least ${YSTDLIB_CPP_CMAKE_CXX_COMPILER_MIN_VERSION}."
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,17 @@
 cmake_minimum_required(VERSION 3.16.3)
 
 # Force minimum compiler versions to support full C++20 features
-set(CMAKE_CXX_COMPILER_MIN_VERSION "")
 if("AppleClang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
 elseif("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
 elseif("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     set(CMAKE_CXX_COMPILER_MIN_VERSION "11.4")
+else()
+    # Unset the minimum required version variable so the comparison test always evaluates to true
+    set(CMAKE_CXX_COMPILER_MIN_VERSION "")
 endif()
-if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS ${CMAKE_CXX_COMPILER_MIN_VERSION})
+if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "${CMAKE_CXX_COMPILER_MIN_VERSION}")
     message(
         FATAL_ERROR
         "${CMAKE_CXX_COMPILER_ID} version must be at least ${CMAKE_CXX_COMPILER_MIN_VERSION}!"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,10 @@ elseif("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
 elseif("GNU" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     set(CMAKE_CXX_COMPILER_MIN_VERSION "11.4")
 else()
-    # Unset the minimum required version variable so the comparison test always evaluates to true
-    set(CMAKE_CXX_COMPILER_MIN_VERSION "")
+    message(
+        FATAL_ERROR
+        "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}. Please use AppleClang, Clang, or GNU."
+    )
 endif()
 if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "${CMAKE_CXX_COMPILER_MIN_VERSION}")
     message(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16.3)
 
+project(YSTDLIB_CPP LANGUAGES CXX)
+
+set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")
+
 # Force minimum compiler versions to support full C++20 features
 if("AppleClang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     set(CMAKE_CXX_COMPILER_MIN_VERSION "16")
@@ -19,10 +23,6 @@ if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "${CMAKE_CXX_COMPILER_MIN_VERSIO
         "${CMAKE_CXX_COMPILER_ID} version must be at least ${CMAKE_CXX_COMPILER_MIN_VERSION}!"
     )
 endif()
-
-project(YSTDLIB_CPP LANGUAGES CXX)
-
-set(YSTDLIB_CPP_VERSION "0.0.1" CACHE STRING "Project version.")
 
 # Enable exporting compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

With future's possible inclusion of `std::source_location`, the default compiler versions on each system (Ubuntu or Darwin) no longer guarantee the comparability of `ystdlib-cpp` and its functional correctness. Therefore, we explicitly enforce a minimum version for each compiler that we use. These minimum versions can be updated in the future should we decide to use more advanced/modern C++ features.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] All existing GitHub workflow machines pass the compiler test.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the build configuration to enforce minimum compiler version requirements for C++20 compatibility. Users will now receive a clear error message if attempting to build with an unsupported compiler version, preventing configuration issues during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->