### PR TITLE
fix(lint): Lock clang-tidy to v19 until we can upgrade our code to fix new v20 issues; Lock clang-format to v19 until we upgrade to newest `yscope-dev-utils` config.

### DIFF
--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,4 +1,5 @@
-clang-format>=20.1
+# Lock to v19.x until we can upgrade our code to fix new v20 issues.
+clang-format>=19.1
 # Lock to v19.x until we can upgrade our code to fix new v20 issues.
 clang-tidy~=19.1
 colorama>=0.4.6

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,5 @@
 # Lock to v19.x until we can upgrade our code to fix new v20 issues.
-clang-format>=19.1
+clang-format~=19.1
 # Lock to v19.x until we can upgrade our code to fix new v20 issues.
 clang-tidy~=19.1
 colorama>=0.4.6

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,6 @@
-clang-format>=19.1.6
-clang-tidy>=19.1.0
+clang-format>=20.1
+# Lock to v19.x until we can upgrade our code to fix new v20 issues.
+clang-tidy~=19.1
 colorama>=0.4.6
 gersemi>=0.16.2
 yamllint>=1.35.1

--- a/src/ystdlib/error_handling/ErrorCode.hpp
+++ b/src/ystdlib/error_handling/ErrorCode.hpp
@@ -87,7 +87,7 @@ public:
     /**
      * @return The reference to the singleton of the corresponded error category.
      */
-    [[nodiscard]] constexpr static auto get_category() -> ErrorCategory<ErrorCodeEnum> const& {
+    [[nodiscard]] static constexpr auto get_category() -> ErrorCategory<ErrorCodeEnum> const& {
         return cCategory;
     }
 

--- a/src/ystdlib/error_handling/ErrorCode.hpp
+++ b/src/ystdlib/error_handling/ErrorCode.hpp
@@ -87,7 +87,7 @@ public:
     /**
      * @return The reference to the singleton of the corresponded error category.
      */
-    [[nodiscard]] static constexpr auto get_category() -> ErrorCategory<ErrorCodeEnum> const& {
+    [[nodiscard]] constexpr static auto get_category() -> ErrorCategory<ErrorCodeEnum> const& {
         return cCategory;
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Issue references:
- https://github.com/y-scope/clp/issues/757
- https://github.com/y-scope/clp/pull/767

We lock clang-format to v19 right now because migrating v20 would require us to update to the newest `yscope-dev-utils`, which would incur a bunch of other changes.

Also clang-tidy v20 generates the following error in `ystdlib-cpp`:

```
ystdlib-cpp/src/ystdlib/error_handling/ErrorCode.hpp:41:24: error: unspecified virtual member function instantiation; the virtual member function is not instantiated but it might be with a different compiler [portability-template-virtual-member-function,-warnings-as-errors]
   41 |     [[nodiscard]] auto message(int error_num) const -> std::string override {
      |                        ^
ystdlib-cpp/src/ystdlib/error_handling/test/types.cpp:23:31: note: template instantiated here
   23 | auto ystdlib::error_handling::ErrorCategory<AlwaysSuccessErrorCodeEnum>::name() const noexcept
      |                               ^
ystdlib-cpp/src/ystdlib/error_handling/ErrorCode.hpp:51:5: error: unspecified virtual member function instantiation; the virtual member function is not instantiated but it might be with a different compiler [portability-template-virtual-member-function,-warnings-as-errors]
   51 |     equivalent(int error_num, std::error_condition const& condition) const noexcept
      |     ^
ystdlib-cpp/src/ystdlib/error_handling/test/types.cpp:23:31: note: template instantiated here
   23 | auto ystdlib::error_handling::ErrorCategory<AlwaysSuccessErrorCodeEnum>::name() const noexcept
      |                               ^
ystdlib-cpp/src/ystdlib/error_handling/test/types.cpp:23:74: error: unspecified virtual member function instantiation; the virtual member function is not instantiated but it might be with a different compiler [portability-template-virtual-member-function,-warnings-as-errors]
   23 | auto ystdlib::error_handling::ErrorCategory<AlwaysSuccessErrorCodeEnum>::name() const noexcept
      |                                                                          ^
ystdlib-cpp/src/ystdlib/error_handling/test/types.cpp:23:31: note: template instantiated here
   23 | auto ystdlib::error_handling::ErrorCategory<AlwaysSuccessErrorCodeEnum>::name() const noexcept
      |                               ^
ystdlib-cpp/src/ystdlib/error_handling/test/types.cpp:41:27: error: unspecified virtual member function instantiation; the virtual member function is not instantiated but it might be with a different compiler [portability-template-virtual-member-function,-warnings-as-errors]
   41 | auto BinaryErrorCategory::name() const noexcept -> char const* {
      |                           ^
ystdlib-cpp/src/ystdlib/error_handling/test/types.cpp:41:6: note: template instantiated here
   41 | auto BinaryErrorCategory::name() const noexcept -> char const* {
      |      ^
Suppressed 969483 warnings (969093 in non-user code, 390 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
4 warnings treated as errors
```




# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] No test required.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted internal dependency version restrictions to lock tool versions to a stable patch series, ensuring consistent quality and preventing unexpected changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->