### PR TITLE
refactor(error_handling): Move `ErrorCategory` definitions from header to source to reduce scope.

### DIFF
--- a/src/ystdlib/error_handling/test/types.cpp
+++ b/src/ystdlib/error_handling/test/types.cpp
@@ -7,9 +7,7 @@
 
 #include "constants.hpp"
 
-using ystdlib::error_handling::test::AlwaysSuccessErrorCategory;
 using ystdlib::error_handling::test::AlwaysSuccessErrorCodeEnum;
-using ystdlib::error_handling::test::BinaryErrorCategory;
 using ystdlib::error_handling::test::BinaryErrorCodeEnum;
 using ystdlib::error_handling::test::cAlwaysSuccessErrorCategoryName;
 using ystdlib::error_handling::test::cBinaryTestErrorCategoryName;
@@ -17,6 +15,9 @@ using ystdlib::error_handling::test::cFailureConditions;
 using ystdlib::error_handling::test::cFailureErrorMsg;
 using ystdlib::error_handling::test::cSuccessErrorMsg;
 using ystdlib::error_handling::test::cUnrecognizedErrorCode;
+using AlwaysSuccessErrorCategory
+        = ystdlib::error_handling::ErrorCategory<AlwaysSuccessErrorCodeEnum>;
+using BinaryErrorCategory = ystdlib::error_handling::ErrorCategory<BinaryErrorCodeEnum>;
 
 template <>
 auto AlwaysSuccessErrorCategory::name() const noexcept -> char const* {

--- a/src/ystdlib/error_handling/test/types.cpp
+++ b/src/ystdlib/error_handling/test/types.cpp
@@ -5,6 +5,8 @@
 #include <string_view>
 #include <system_error>
 
+#include <ystdlib/error_handling/ErrorCode.hpp>
+
 #include "constants.hpp"
 
 using ystdlib::error_handling::test::AlwaysSuccessErrorCodeEnum;

--- a/src/ystdlib/error_handling/test/types.hpp
+++ b/src/ystdlib/error_handling/test/types.hpp
@@ -16,10 +16,7 @@ enum class BinaryErrorCodeEnum : uint8_t {
 };
 
 using AlwaysSuccessErrorCode = ystdlib::error_handling::ErrorCode<AlwaysSuccessErrorCodeEnum>;
-using AlwaysSuccessErrorCategory
-        = ystdlib::error_handling::ErrorCategory<AlwaysSuccessErrorCodeEnum>;
 using BinaryErrorCode = ystdlib::error_handling::ErrorCode<BinaryErrorCodeEnum>;
-using BinaryErrorCategory = ystdlib::error_handling::ErrorCategory<BinaryErrorCodeEnum>;
 }  // namespace ystdlib::error_handling::test
 
 YSTDLIB_ERROR_HANDLING_MARK_AS_ERROR_CODE_ENUM(


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As discussed [here](https://github.com/y-scope/clp/pull/772#discussion_r2004164609), `ErrorCategory` classes don't need to be exposed in the header files.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] unit tests pass.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined and consolidated error handling definitions to create a more concise and consistent public interface, reducing redundancy and improving maintainability. These improvements enhance the clarity and efficiency of error reporting for a smoother user experience. The update does not alter external functionality but lays a more robust foundation for error processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->