### PR TITLE
fix(lint): Register `Catch2` and custom CMake modules with `Gersemi`.

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,6 +1,8 @@
 # yamllint disable-line rule:line-length
 # yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/master/gersemi/configuration.schema.json
 
-definitions: ["CMake/ystdlib-cpp-helpers.cmake"]
+definitions:
+  - "CMake/ystdlib-cpp-helpers.cmake"
+  - "build/deps/Catch2/Catch2-src/extras/Catch.cmake"
 line_length: 100
 list_expansion: "favour-expansion"

--- a/taskfiles/lint-cmake.yaml
+++ b/taskfiles/lint-cmake.yaml
@@ -42,6 +42,7 @@ tasks:
         - "FLAGS"
     dir: "{{.ROOT_DIR}}"
     deps:
+      - ":deps:install-all"  # Allow Gersemi to parse 3rdparty CMake modules for linting
       - "venv"
     cmds:
       - |-


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Currently, our cmake linter tool `gersemi` complains as follows:
```
Warning: unknown command 'catch_discover_tests' used at: ...
```
We silence this warning by adding related `Catch2` cmake modules to `.gersemirc`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] No functionality change. Linting warning message disappears now.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced clarity of configuration settings by updating the `definitions` key to a multi-line format.
  - Introduced an additional dependency in the `gersemi` task to support parsing of third-party CMake modules during linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->