### PR TITLE
feat(cmake): Enhance `cpp_library()` with argument validation, test-only linking, and improved docstrings.

### DIFF
--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -89,12 +89,6 @@ function(cpp_library)
 
     check_if_header_only(arg_cpp_lib_PRIVATE_SOURCES _IS_INTERFACE_LIB _)
     if(_IS_INTERFACE_LIB)
-        if(arg_cpp_lib_PRIVATE_LINK_LIBRARIES)
-            message(
-                FATAL_ERROR
-                "Private dependency specifications disabled for interface library target ${_ALIAS_TARGET_NAME}."
-            )
-        endif()
         add_library(${arg_cpp_lib_NAME} INTERFACE)
         target_include_directories(
             ${arg_cpp_lib_NAME}
@@ -118,15 +112,16 @@ function(cpp_library)
             PUBLIC
                 "$<BUILD_INTERFACE:${arg_cpp_lib_BUILD_INCLUDE_DIR}>"
         )
-        target_link_libraries(
-            ${arg_cpp_lib_NAME}
-            PUBLIC
-                ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
-            PRIVATE
-                ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
-        )
         target_compile_features(${arg_cpp_lib_NAME} PUBLIC cxx_std_20)
     endif()
+
+	target_link_libraries(
+		${arg_cpp_lib_NAME}
+		PUBLIC
+			${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
+		PRIVATE
+			${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
+	)
 
     add_library(${_ALIAS_TARGET_NAME} ALIAS ${arg_cpp_lib_NAME})
 

--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -1,6 +1,6 @@
-# @param REQUIRED_ARGS The list of arguments to check.
-# @param ARG_KEYWORDS_MISSING_VALUES The list of arguments with missing values.
-# @param LIB_NAME The library target on which to perform the check.
+# @param {string[]} REQUIRED_ARGS The list of arguments to check.
+# @param {string[]} ARG_KEYWORDS_MISSING_VALUES The list of arguments with missing values.
+# @param {string} LIB_NAME The library target on which to perform the check.
 function(require_argument_values REQUIRED_ARGS ARG_KEYWORDS_MISSING_VALUES LIB_NAME)
     foreach(arg IN LISTS REQUIRED_ARGS)
         if("${arg}" IN_LIST ARG_KEYWORDS_MISSING_VALUES)
@@ -9,9 +9,9 @@ function(require_argument_values REQUIRED_ARGS ARG_KEYWORDS_MISSING_VALUES LIB_N
     endforeach()
 endfunction()
 
-# @param SOURCE_LIST The list of source files to check.
-# @param IS_HEADER_ONLY Returns whether the list only contains header files.
-# @param NON_HEADER_FILE Returns the name of the first, if any, non-header file.
+# @param {string[]} SOURCE_LIST The list of source files to check.
+# @param {bool} IS_HEADER_ONLY Returns whether the list only contains header files.
+# @param {string} NON_HEADER_FILE Returns the name of the first, if any, non-header file.
 function(check_if_header_only SOURCE_LIST IS_HEADER_ONLY NON_HEADER_FILE)
     set(_LOCAL_SOURCE_LIST "${${SOURCE_LIST}}")
     foreach(src_file IN LISTS _LOCAL_SOURCE_LIST)

--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -34,11 +34,11 @@ endfunction()
 # @param {string} NAME
 # @param {string} NAMESPACE
 # @param {string[]} PUBLIC_HEADERS
-# @parms {string[]} TESTS_SOURCES
+# @param {string[]} TESTS_SOURCES
 # @param {string[]} [PRIVATE_SOURCES]
 # @param {string[]} [PUBLIC_LINK_LIBRARIES]
 # @param {string[]} [PRIVATE_LINK_LIBRARIES]
-# @parms {string[]} [TESTS_LINK_LIBRARIES]
+# @param {string[]} [TESTS_LINK_LIBRARIES]
 # @param {string[]} [BUILD_INCLUDE_DIR="${PROJECT_SOURCE_DIR}/src"] The list of include paths for
 # building the library and for external projects that builds `ystdlib-cpp` as a CMAKE subproject via
 # the add_subdirectory() function.

--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -1,3 +1,14 @@
+# @param REQUIRED_ARGS The list of arguments to check.
+# @param ARG_KEYWORDS_MISSING_VALUES The list of arguments with missing values.
+# @param LIB_NAME The library target on which to perform the check.
+function(require_argument_values REQUIRED_ARGS ARG_KEYWORDS_MISSING_VALUES LIB_NAME)
+    foreach(arg IN LISTS REQUIRED_ARGS)
+        if("${arg}" IN_LIST ARG_KEYWORDS_MISSING_VALUES)
+            message(FATAL_ERROR "Missing values for argument '${arg}' in target '${LIB_NAME}'.")
+        endif()
+    endforeach()
+endfunction()
+
 # @param SOURCE_LIST The list of source files to check.
 # @param IS_HEADER_ONLY Returns whether the list only contains header files.
 # @param NON_HEADER_FILE Returns the name of the first, if any, non-header file.
@@ -20,16 +31,17 @@ endfunction()
 # If `YSTDLIB_CPP_ENABLE_TESTS` is ON, builds the unit tests specific to the current library, and
 # links this library against the unified unit test target for the entire `ystdlib-cpp` project.
 #
-# @param NAME
-# @param NAMESPACE
-# @param PUBLIC_HEADERS
-# @param PRIVATE_SOURCES
-# @param PUBLIC_LINK_LIBRARIES
-# @param PRIVATE_LINK_LIBRARIES
-# @parms TESTS_SOURCES
-# @param [BUILD_INCLUDE_DIR="${PROJECT_SOURCE_DIR}/src"] The list of include paths for building the
-# library and for external projects that builds `ystdlib-cpp` as a CMAKE subproject via the
-# add_subdirectory() function.
+# @param {string} NAME
+# @param {string} NAMESPACE
+# @param {string[]} PUBLIC_HEADERS
+# @parms {string[]} TESTS_SOURCES
+# @param {string[]} [PRIVATE_SOURCES]
+# @param {string[]} [PUBLIC_LINK_LIBRARIES]
+# @param {string[]} [PRIVATE_LINK_LIBRARIES]
+# @parms {string[]} [TESTS_LINK_LIBRARIES]
+# @param {string[]} [BUILD_INCLUDE_DIR="${PROJECT_SOURCE_DIR}/src"] The list of include paths for
+# building the library and for external projects that builds `ystdlib-cpp` as a CMAKE subproject via
+# the add_subdirectory() function.
 function(cpp_library)
     set(options "")
     set(oneValueArgs
@@ -42,16 +54,28 @@ function(cpp_library)
         PUBLIC_LINK_LIBRARIES
         PRIVATE_LINK_LIBRARIES
         TESTS_SOURCES
+        TESTS_LINK_LIBRARIES
         BUILD_INCLUDE_DIR
     )
+    set(requireValueArgs
+        NAME
+        NAMESPACE
+        PUBLIC_HEADERS
+        TESTS_SOURCES
+        BUILD_INCLUDE_DIR
+    )
+
     cmake_parse_arguments(arg_cpp_lib "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(_ALIAS_TARGET_NAME "${arg_cpp_lib_NAMESPACE}::${arg_cpp_lib_NAME}")
 
-    # TODO: Turn this into a function for handling other optional params that have default values.
-    if("BUILD_INCLUDE_DIR" IN_LIST arg_cpp_lib_KEYWORDS_MISSING_VALUES)
-        message(FATAL_ERROR "Missing build interface list for ${_ALIAS_TARGET_NAME}.")
-    elseif(NOT DEFINED arg_cpp_lib_BUILD_INCLUDE_DIR)
+    require_argument_values(
+        "${requireValueArgs}"
+        "${arg_cpp_lib_KEYWORDS_MISSING_VALUES}"
+        "${_ALIAS_TARGET_NAME}"
+    )
+
+    if(NOT DEFINED arg_cpp_lib_BUILD_INCLUDE_DIR)
         set(arg_cpp_lib_BUILD_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/src")
     endif()
 
@@ -65,12 +89,19 @@ function(cpp_library)
 
     check_if_header_only(arg_cpp_lib_PRIVATE_SOURCES _IS_INTERFACE_LIB _)
     if(_IS_INTERFACE_LIB)
+        if(arg_cpp_lib_PRIVATE_LINK_LIBRARIES)
+            message(
+                FATAL_ERROR
+                "Private dependency specifications disabled for interface library target ${_ALIAS_TARGET_NAME}."
+            )
+        endif()
         add_library(${arg_cpp_lib_NAME} INTERFACE)
         target_include_directories(
             ${arg_cpp_lib_NAME}
             INTERFACE
                 "$<BUILD_INTERFACE:${arg_cpp_lib_BUILD_INCLUDE_DIR}>"
         )
+        target_link_libraries(${arg_cpp_lib_NAME} INTERFACE ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES})
         target_compile_features(${arg_cpp_lib_NAME} INTERFACE cxx_std_20)
     else()
         # The library type is specified by `BUILD_SHARED_LIBS` if it is defined. Otherwise, the type
@@ -87,16 +118,16 @@ function(cpp_library)
             PUBLIC
                 "$<BUILD_INTERFACE:${arg_cpp_lib_BUILD_INCLUDE_DIR}>"
         )
+        target_link_libraries(
+            ${arg_cpp_lib_NAME}
+            PUBLIC
+                ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
+            PRIVATE
+                ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
+        )
         target_compile_features(${arg_cpp_lib_NAME} PUBLIC cxx_std_20)
     endif()
 
-    target_link_libraries(
-        ${arg_cpp_lib_NAME}
-        PUBLIC
-            ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
-        PRIVATE
-            ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
-    )
     add_library(${_ALIAS_TARGET_NAME} ALIAS ${arg_cpp_lib_NAME})
 
     if(YSTDLIB_CPP_ENABLE_TESTS)
@@ -109,6 +140,7 @@ function(cpp_library)
             PRIVATE
                 Catch2::Catch2WithMain
                 ${_ALIAS_TARGET_NAME}
+                ${arg_cpp_lib_TESTS_LINK_LIBRARIES}
         )
         target_compile_features(${_UNIT_TEST_TARGET} PRIVATE cxx_std_20)
         set_property(
@@ -121,6 +153,11 @@ function(cpp_library)
 
         # Link against unified unit test
         target_sources(${UNIFIED_UNIT_TEST_TARGET} PRIVATE ${arg_cpp_lib_TESTS_SOURCES})
-        target_link_libraries(${UNIFIED_UNIT_TEST_TARGET} PRIVATE ${_ALIAS_TARGET_NAME})
+        target_link_libraries(
+            ${UNIFIED_UNIT_TEST_TARGET}
+            PRIVATE
+                ${_ALIAS_TARGET_NAME}
+                ${arg_cpp_lib_TESTS_LINK_LIBRARIES}
+        )
     endif()
 endfunction()

--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -1,16 +1,16 @@
 # @param {string[]} REQUIRED_ARGS The list of arguments to check.
 # @param {string[]} ARG_KEYWORDS_MISSING_VALUES The list of arguments with missing values.
-# @param {string} LIB_NAME The library target on which to perform the check.
-function(require_argument_values REQUIRED_ARGS ARG_KEYWORDS_MISSING_VALUES LIB_NAME)
+# @param {string} TARGET_NAME The target on which to perform the check.
+function(require_argument_values REQUIRED_ARGS ARG_KEYWORDS_MISSING_VALUES TARGET_NAME)
     foreach(arg IN LISTS REQUIRED_ARGS)
         if("${arg}" IN_LIST ARG_KEYWORDS_MISSING_VALUES)
-            message(FATAL_ERROR "Missing values for argument '${arg}' in target '${LIB_NAME}'.")
+            message(FATAL_ERROR "Missing values for argument '${arg}' in target '${TARGET_NAME}'.")
         endif()
     endforeach()
 endfunction()
 
 # @param {string[]} SOURCE_LIST The list of source files to check.
-# @param {bool} IS_HEADER_ONLY Returns whether the list only contains header files.
+# @param {bool} IS_HEADER_ONLY Returns TRUE if list only contains header files, FALSE otherwise.
 # @param {string} NON_HEADER_FILE Returns the name of the first, if any, non-header file.
 function(check_if_header_only SOURCE_LIST IS_HEADER_ONLY NON_HEADER_FILE)
     set(_LOCAL_SOURCE_LIST "${${SOURCE_LIST}}")

--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -120,7 +120,6 @@ function(cpp_library)
         PRIVATE
             ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
     )
-
     add_library(${_ALIAS_TARGET_NAME} ALIAS ${arg_cpp_lib_NAME})
 
     if(YSTDLIB_CPP_ENABLE_TESTS)

--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -64,7 +64,6 @@ function(cpp_library)
         TESTS_SOURCES
         BUILD_INCLUDE_DIR
     )
-
     cmake_parse_arguments(arg_cpp_lib "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(_ALIAS_TARGET_NAME "${arg_cpp_lib_NAMESPACE}::${arg_cpp_lib_NAME}")
@@ -95,7 +94,6 @@ function(cpp_library)
             INTERFACE
                 "$<BUILD_INTERFACE:${arg_cpp_lib_BUILD_INCLUDE_DIR}>"
         )
-        target_link_libraries(${arg_cpp_lib_NAME} INTERFACE ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES})
         target_compile_features(${arg_cpp_lib_NAME} INTERFACE cxx_std_20)
     else()
         # The library type is specified by `BUILD_SHARED_LIBS` if it is defined. Otherwise, the type
@@ -115,13 +113,13 @@ function(cpp_library)
         target_compile_features(${arg_cpp_lib_NAME} PUBLIC cxx_std_20)
     endif()
 
-	target_link_libraries(
-		${arg_cpp_lib_NAME}
-		PUBLIC
-			${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
-		PRIVATE
-			${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
-	)
+    target_link_libraries(
+        ${arg_cpp_lib_NAME}
+        PUBLIC
+            ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
+        PRIVATE
+            ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
+    )
 
     add_library(${_ALIAS_TARGET_NAME} ALIAS ${arg_cpp_lib_NAME})
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR refactors and improves the `cpp_library()` CMake function:
* Added `require_argument_values()` helper to enforce argument check in a fail-fast way.
* Add a new option `TESTS_LINK_LIBRARIES` for 3rdparty libraries that are not used in implementation but are used for testing purposes for a target library.
* Improve all doc strings with variable type specifications.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] No functionality changes.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced library configuration with improved argument validation to ensure all required inputs are provided, reducing build misconfigurations.
  - Updated the linking process to improve handling of public, private, and test dependencies for a more robust building experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->