### PR TITLE
fix(cmake): Correct linking of dependencies for interface (header-only) libraries.

### DIFF
--- a/CMake/ystdlib-cpp-helpers.cmake
+++ b/CMake/ystdlib-cpp-helpers.cmake
@@ -65,7 +65,14 @@ function(cpp_library)
 
     check_if_header_only(arg_cpp_lib_PRIVATE_SOURCES _IS_INTERFACE_LIB _)
     if(_IS_INTERFACE_LIB)
+        if(arg_cpp_lib_PRIVATE_LINK_LIBRARIES)
+            message(
+                FATAL_ERROR
+                "`PRIVATE_LINK_LIBRARIES` disabled for header-only library ${_ALIAS_TARGET_NAME}."
+            )
+        endif()
         add_library(${arg_cpp_lib_NAME} INTERFACE)
+        target_link_libraries(${arg_cpp_lib_NAME} INTERFACE ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES})
         target_include_directories(
             ${arg_cpp_lib_NAME}
             INTERFACE
@@ -82,6 +89,13 @@ function(cpp_library)
                 ${arg_cpp_lib_PUBLIC_HEADERS}
                 ${arg_cpp_lib_PRIVATE_SOURCES}
         )
+        target_link_libraries(
+            ${arg_cpp_lib_NAME}
+            PUBLIC
+                ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
+            PRIVATE
+                ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
+        )
         target_include_directories(
             ${arg_cpp_lib_NAME}
             PUBLIC
@@ -90,13 +104,6 @@ function(cpp_library)
         target_compile_features(${arg_cpp_lib_NAME} PUBLIC cxx_std_20)
     endif()
 
-    target_link_libraries(
-        ${arg_cpp_lib_NAME}
-        PUBLIC
-            ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
-        PRIVATE
-            ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
-    )
     add_library(${_ALIAS_TARGET_NAME} ALIAS ${arg_cpp_lib_NAME})
 
     if(YSTDLIB_CPP_ENABLE_TESTS)


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

For header-only libraries, we add the target using `add_library(${arg_cpp_lib_NAME} INTERFACE)` call, making it an interface target. For interface targets, doing the following will fail
```cmake
target_link_libraries(
    ${arg_cpp_lib_NAME}
    PUBLIC
        ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
    PRIVATE
        ${arg_cpp_lib_PRIVATE_LINK_LIBRARIES}
)
```
as interface targets can only have `INTERFACE` properties.
Instead of adding a new arg called `INTERFACE_LINK_LIBRARIES` to `cpp_library()`, we keep using `PUBLIC_LINK_LIBRARIES`:
```cmake
target_link_libraries(
    ${arg_cpp_lib_NAME}
    INTERFACE
        ${arg_cpp_lib_PUBLIC_LINK_LIBRARIES}
)
```
and forbids users from specifying `PRIVATE_LINK_LIBRARIES` as interface dependencies will get propagated.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Cmake helper function fix. Targets compile successfully as usual.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
