### PR TITLE
feat: Use `install-boost` instead of  `install-outcome` and `install-quickcpplib`.

### DIFF
--- a/taskfiles/deps.yaml
+++ b/taskfiles/deps.yaml
@@ -69,42 +69,22 @@ tasks:
           NAME: "{{.G_CATCH2_LIB_NAME}}"
           INSTALL_PREFIX: "{{.G_CATCH2_WORK_DIR}}/{{.G_CATCH2_LIB_NAME}}-install"
 
-  install-outcome:
+  install-boost:
     internal: true
     run: "once"
-    deps:
-      - "install-quickcpplib"
     cmds:
-      - task: ":utils:cmake-install-remote-tar"
+      - task: "boost-download-and-install"
         vars:
-          NAME: "{{.G_OUTCOME_LIB_NAME}}"
-          WORK_DIR: "{{.G_OUTCOME_WORK_DIR}}"
-          FILE_SHA256: "0382248cbb00806ce4b5f3ce6939797dc3b597c85fd3531614959e31ef488b39"
-          URL: "https://github.com/ned14/outcome/archive/refs/tags/v2.2.11.tar.gz"
-          GEN_ARGS:
-            - "-C {{.G_DEPS_CMAKE_SETTINGS_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}.cmake"
-            - "-DBUILD_TESTING=OFF"
-            - "-DCMAKE_BUILD_TYPE=Release"
-            - "-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"
-      - task: "add-package-root-to-cmake-settings"
-        vars:
-          NAME: "{{.G_OUTCOME_LIB_NAME}}"
-          INSTALL_PREFIX: "{{.G_OUTCOME_WORK_DIR}}/{{.G_OUTCOME_LIB_NAME}}-install"
+          WORK_DIR: "{{.G_DEPS_DIR}}/boost"
+          FILE_SHA256: "2128a4c96862b5c0970c1e34d76b1d57e4a1016b80df85ad39667f30b1deba26"
+          URL: "https://github.com/boostorg/boost/releases/download/boost-1.86.0/\
+            boost-1.86.0-b2-nodocs.tar.gz"
+          CMAKE_SETTINGS_DIR: "{{.G_DEPS_CMAKE_SETTINGS_DIR}}"
+          TARGETS:
+            - "filesystem"
+            - "iostreams"
+            - "process"
+            - "program_options"
+            - "regex"
+            - "system" 
 
-  install-quickcpplib:
-    internal: true
-    run: "once"
-    cmds:
-      - task: ":utils:cmake-install-remote-tar"
-        vars:
-          NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"
-          WORK_DIR: "{{.G_QUICKCPPLIB_WORK_DIR}}"
-          FILE_SHA256: "5d4c9b2d6fa177d3fb14f3fe3086867e43b44f4a7a944eb10ee4616b2b0f3c05"
-          URL: "https://github.com/ned14/quickcpplib/archive/f3e452e.tar.gz"
-          GEN_ARGS:
-            - "-DBUILD_TESTING=OFF"
-            - "-DCMAKE_BUILD_TYPE=Release"
-      - task: "add-package-root-to-cmake-settings"
-        vars:
-          NAME: "{{.G_QUICKCPPLIB_LIB_NAME}}"
-          INSTALL_PREFIX: "{{.G_QUICKCPPLIB_WORK_DIR}}/{{.G_QUICKCPPLIB_LIB_NAME}}-install"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Install `outcome` and `quickcpplib` from Boost's components.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [ ] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [ ] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [ ] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
