### PR TITLE
fix(lint): Update to latest version of gersemi and apply corresponding format changes.

### DIFF
--- a/cmake/ystdlib-helpers.cmake
+++ b/cmake/ystdlib-helpers.cmake
@@ -106,11 +106,12 @@ function(add_cpp_library)
     target_sources(
         ${ARG_NAME}
         PUBLIC
-            FILE_SET HEADERS
-            BASE_DIRS
-                "$<BUILD_INTERFACE:${ARG_BUILD_INCLUDE_DIRS}>"
-                "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-            FILES ${ARG_PUBLIC_HEADERS}
+            FILE_SET
+            HEADERS
+                BASE_DIRS
+                    "$<BUILD_INTERFACE:${ARG_BUILD_INCLUDE_DIRS}>"
+                    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+                FILES ${ARG_PUBLIC_HEADERS}
     )
 endfunction()
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,5 +1,5 @@
 clang-format>=20.1.0
 clang-tidy>=19.1.0
 colorama>=0.4.6
-gersemi>=0.16.2
+gersemi>=0.20.0
 yamllint>=1.35.1


### PR DESCRIPTION

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Recently, the linting CI is failing due to a new version of gersemi requiring code formatting changes (e.g. https://github.com/y-scope/ystdlib-cpp/actions/runs/16106150197/job/45441911050). This PR applies the change and also bumps the version in `lint-requirements.txt` to reflect the latest version.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

CI and gersemi passing.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting in build configuration files for improved clarity.
  * Increased minimum required version of the `gersemi` package for linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->